### PR TITLE
feat: add options to enable extract and publish without prompting for user input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-## <small>1.0.3 (2021-02-26)</small>
-
-- feat: add options to specify module and checkpoint for publish and extract ([627175d](https://github.com/Thinkful-Ed/authoroo/commit/627175d))
-- style: run prettier ([fb9df32](https://github.com/Thinkful-Ed/authoroo/commit/fb9df32))
-- docs(readme): remove reference to `zid` modules ([06cff94](https://github.com/Thinkful-Ed/authoroo/commit/06cff94))
-- docs(readme): update readme with new publish command ([f716e1d](https://github.com/Thinkful-Ed/authoroo/commit/f716e1d))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## <small>1.0.3 (2021-02-26)</small>
+
+- feat: add options to specify module and checkpoint for publish and extract ([627175d](https://github.com/Thinkful-Ed/authoroo/commit/627175d))
+- style: run prettier ([fb9df32](https://github.com/Thinkful-Ed/authoroo/commit/fb9df32))
+- docs(readme): remove reference to `zid` modules ([06cff94](https://github.com/Thinkful-Ed/authoroo/commit/06cff94))
+- docs(readme): update readme with new publish command ([f716e1d](https://github.com/Thinkful-Ed/authoroo/commit/f716e1d))

--- a/index.js
+++ b/index.js
@@ -23,11 +23,19 @@ const config = yargs
     ["$0 init", "Initialize the checkpoints specified in the module file"],
     [
       "$0 extract -q <qualified-api-key>",
-      "Extract an assessment from qualified.io into the selected checkpoint's '/qualified' folder.",
+      "Prompt for a module, checkpoint, and assessment-id, then extract an assessment from qualified.io into the selected checkpoint's '/qualified' folder.",
+    ],
+    [
+      "$0 extract -q <qualified-api-key> -a [assessment-id] -c [checkpoint-folder]",
+      "Extract the specified assessment-id from qualified.io into the specified checkpoint's '/qualified' folder.",
     ],
     [
       "$0 publish -q <qualified-api-key>",
-      "Publish the selected checkpoint's '/qualified' folder to qualified.io",
+      "Prompt for a module and checkpoint, then publish the checkpoint's '/qualified' folder to qualified.io",
+    ],
+    [
+      "$0 publish -q <qualified-api-key> -c [checkpoint-folder] ",
+      "Publish the specified checkpoint's '/qualified' folder to qualified.io",
     ],
     [
       "DEBUG=* $0 <command>",

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const config = yargs
       "Prompt for a module, checkpoint, and assessment-id, then extract an assessment from qualified.io into the selected checkpoint's '/qualified' folder.",
     ],
     [
-      "$0 extract -q <qualified-api-key> -a [assessment-id] -c [checkpoint-folder]",
+      "$0 extract -q <qualified-api-key> -a [assessment-id] -c [checkpoint-folder] -p [docker-port]",
       "Extract the specified assessment-id from qualified.io into the specified checkpoint's '/qualified' folder.",
     ],
     [

--- a/lib/extract-command/index.js
+++ b/lib/extract-command/index.js
@@ -34,7 +34,7 @@ const packageJson = `{
     "jest-reporter": "^1.0.1"
   }
 }
-`
+`;
 
 const questions = [
   {
@@ -48,20 +48,23 @@ const command = "extract";
 const describe =
   "Prompts for a module and checkpoint, then extracts the files from the qualified challenge into the checkpoint's `qualified` folder, overwriting any existing files. If there is an existing assessment.json file in the checkpoint, this command will use the assessmentId from the existing assessment.json file, otherwise it will prompt for the assessmentId. No files are deleted.";
 
-function builder (yargs) {
-  return yargs.config().option("q", {
-    alias: "qualifiedApiKey",
-    demandOption: true,
-    describe:
-      "Qualified API access key copied from https://www.qualified.io/hire/account/integrations#api-key.",
-    nargs: 1,
-    type: "string",
-  })
+function builder(yargs) {
+  return yargs
+    .config()
+    .option("q", {
+      alias: "qualifiedApiKey",
+      demandOption: true,
+      describe:
+        "Qualified API access key copied from https://www.qualified.io/hire/account/integrations#api-key.",
+      nargs: 1,
+      type: "string",
+    })
     .option("c", {
       alias: "checkpoint-folder",
       demandOption: false,
       type: "string",
-      describe: "the path of the checkpoint folder inside of library (omit `./library` i.e. `<checkpoint-folder-name>`",
+      describe:
+        "the path of the checkpoint folder inside of library (omit `./library` i.e. `<checkpoint-folder-name>`",
     })
     .option("a", {
       alias: "assessment-id",
@@ -77,8 +80,9 @@ function builder (yargs) {
     });
 }
 
-async function handler (config) {
-  const checkpoint = config["checkpoint-folder"] || await selectCheckpoint(config.webDevPath);
+async function handler(config) {
+  const checkpoint =
+    config["checkpoint-folder"] || (await selectCheckpoint(config.webDevPath));
 
   const checkpointFolder = path.join(config.webDevPath, "library", checkpoint);
   const qualifiedFolder = path.join(checkpointFolder, "qualified");
@@ -96,7 +100,10 @@ async function handler (config) {
 
   const assessmentId = assessmentExists
     ? require(assessmentFile).data.id
-    : config["assessment-id"] || await inquirer.prompt(questions).then((answers) => answers.assessmentId);
+    : config["assessment-id"] ||
+      (await inquirer
+        .prompt(questions)
+        .then((answers) => answers.assessmentId));
 
   const challenge = await writeAssessmentAndChallenge(
     assessmentId,
@@ -131,22 +138,30 @@ async function handler (config) {
     },
   ];
 
-  const answers = config["docker-port"] ? { port: config["docker-port"] } : await inquirer.prompt(moreQuestions);
+  const answers = config["docker-port"]
+    ? { port: config["docker-port"] }
+    : await inquirer.prompt(moreQuestions);
 
-  await writeDockerFiles(qualifiedFolder, { ...answers, checkpoint: checkpoint.toLowerCase() });
+  await writeDockerFiles(qualifiedFolder, {
+    ...answers,
+    checkpoint: checkpoint.toLowerCase(),
+  });
 
   const packageJsonFile = path.join(qualifiedFolder, "package.json");
 
   if (!fs.existsSync(packageJson)) {
-    const packageJsonTemplate = Handlebars.compile(packageJson)
-    const contents = packageJsonTemplate({ ...answers, checkpoint: checkpoint.toLowerCase() })
-    fs.writeFileSync(packageJsonFile, contents)
+    const packageJsonTemplate = Handlebars.compile(packageJson);
+    const contents = packageJsonTemplate({
+      ...answers,
+      checkpoint: checkpoint.toLowerCase(),
+    });
+    fs.writeFileSync(packageJsonFile, contents);
   }
 
   console.log("Done");
 }
 
-function writeFile (destinationFolder) {
+function writeFile(destinationFolder) {
   return (file) => {
     const filePath = path.join(destinationFolder, file.path);
     const folder = path.dirname(filePath);

--- a/lib/extract-command/index.js
+++ b/lib/extract-command/index.js
@@ -1,12 +1,40 @@
 const fs = require("fs");
-
+const Handlebars = require("handlebars");
 const inquirer = require("inquirer");
 const path = require("path");
+
 const selectCheckpoint = require("../select-checkpoint");
 const writeAssessmentAndChallenge = require("../write-assessment-and-challenge");
 const writeDockerFiles = require("../write-docker-files");
 
 const debug = require("debug")("authoroo:extract");
+
+const packageJson = `{
+  "name": "{{checkpoint}}",
+  "version": "1.0.0",
+  "description": "{{checkpoint}} qualified challenge.",
+  "main": "jest.config.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "docker:build": "docker image build . -t thinkful-ed/{{checkpoint}}",
+    "docker:run": "docker run --rm -it -p {{port}}:{{port}} thinkful-ed/{{checkpoint}}",
+    "docker:stop": "docker stop $(docker ps -q)",
+    "docker:test": "docker run -it thinkful-ed/{{checkpoint}} npm test",
+    "start:solution": "npm run -it docker:build && npm run docker:run",
+    "test": "jest",
+    "test:solution": "npm run docker:build && npm run docker:test"
+  },
+  "keywords": [],
+  "author": "Thinkful.com",
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "jest": "^26.6.3",
+    "jest-reporter": "^1.0.1"
+  }
+}
+`
 
 const questions = [
   {
@@ -20,7 +48,7 @@ const command = "extract";
 const describe =
   "Prompts for a module and checkpoint, then extracts the files from the qualified challenge into the checkpoint's `qualified` folder, overwriting any existing files. If there is an existing assessment.json file in the checkpoint, this command will use the assessmentId from the existing assessment.json file, otherwise it will prompt for the assessmentId. No files are deleted.";
 
-function builder(yargs) {
+function builder (yargs) {
   return yargs.config().option("q", {
     alias: "qualifiedApiKey",
     demandOption: true,
@@ -28,11 +56,29 @@ function builder(yargs) {
       "Qualified API access key copied from https://www.qualified.io/hire/account/integrations#api-key.",
     nargs: 1,
     type: "string",
-  });
+  })
+    .option("c", {
+      alias: "checkpoint-folder",
+      demandOption: false,
+      type: "string",
+      describe: "the path of the checkpoint folder inside of library (omit `./library` i.e. `<checkpoint-folder-name>`",
+    })
+    .option("a", {
+      alias: "assessment-id",
+      demandOption: false,
+      type: "string",
+      describe: "the id of the assessment",
+    })
+    .option("p", {
+      alias: "docker-port",
+      demandOption: false,
+      type: "number",
+      describe: "the port exposed by docker",
+    });
 }
 
-async function handler(config) {
-  const checkpoint = await selectCheckpoint(config.webDevPath);
+async function handler (config) {
+  const checkpoint = config["checkpoint-folder"] || await selectCheckpoint(config.webDevPath);
 
   const checkpointFolder = path.join(config.webDevPath, "library", checkpoint);
   const qualifiedFolder = path.join(checkpointFolder, "qualified");
@@ -50,7 +96,7 @@ async function handler(config) {
 
   const assessmentId = assessmentExists
     ? require(assessmentFile).data.id
-    : await inquirer.prompt(questions).then((answers) => answers.assessmentId);
+    : config["assessment-id"] || await inquirer.prompt(questions).then((answers) => answers.assessmentId);
 
   const challenge = await writeAssessmentAndChallenge(
     assessmentId,
@@ -85,14 +131,22 @@ async function handler(config) {
     },
   ];
 
-  const answers = await inquirer.prompt(moreQuestions);
+  const answers = config["docker-port"] ? { port: config["docker-port"] } : await inquirer.prompt(moreQuestions);
 
-  await writeDockerFiles(qualifiedFolder, { ...answers, checkpoint });
+  await writeDockerFiles(qualifiedFolder, { ...answers, checkpoint: checkpoint.toLowerCase() });
+
+  const packageJsonFile = path.join(qualifiedFolder, "package.json");
+
+  if (!fs.existsSync(packageJson)) {
+    const packageJsonTemplate = Handlebars.compile(packageJson)
+    const contents = packageJsonTemplate({ ...answers, checkpoint: checkpoint.toLowerCase() })
+    fs.writeFileSync(packageJsonFile, contents)
+  }
 
   console.log("Done");
 }
 
-function writeFile(destinationFolder, config) {
+function writeFile (destinationFolder) {
   return (file) => {
     const filePath = path.join(destinationFolder, file.path);
     const folder = path.dirname(filePath);

--- a/lib/publish-command/index.js
+++ b/lib/publish-command/index.js
@@ -16,25 +16,29 @@ const describe =
   "Prompts for a module and then checkpoint, then publishes the checkpoint's `qualified` folder to a challenge. If there are existing assessment.json and challenge.json files in the checkpoint folder, the challenge is updated, otherwise a new assessment and challenge are created.";
 
 function builder(yargs) {
-  return yargs.config().option("q", {
-    alias: "qualifiedApiKey",
-    demandOption: true,
-    describe:
-      "Qualified API access key copied from https://www.qualified.io/hire/account/integrations#api-key.",
-    nargs: 1,
-    type: "string",
-  })
+  return yargs
+    .config()
+    .option("q", {
+      alias: "qualifiedApiKey",
+      demandOption: true,
+      describe:
+        "Qualified API access key copied from https://www.qualified.io/hire/account/integrations#api-key.",
+      nargs: 1,
+      type: "string",
+    })
     .option("m", {
       alias: "module-name",
       demandOption: false,
       type: "string",
-      describe: "the name of the module.yaml (without the .yaml extension) file that defines the module",
+      describe:
+        "the name of the module.yaml (without the .yaml extension) file that defines the module",
     })
     .option("c", {
       alias: "checkpoint-folder",
       demandOption: false,
       type: "string",
-      describe: "the path of the checkpoint folder inside of library (omit `./library` i.e. `<checkpoint-folder-name>`",
+      describe:
+        "the path of the checkpoint folder inside of library (omit `./library` i.e. `<checkpoint-folder-name>`",
     });
 }
 
@@ -45,9 +49,15 @@ async function handler(config) {
     Accept: "application/json",
   };
 
-  const module = config["module-name"] ? await readYaml(path.join(config.webDevPath, "modules", `${config["module-name"]}.yaml` ))  : await selectModule(config.webDevPath);
+  const module = config["module-name"]
+    ? await readYaml(
+        path.join(config.webDevPath, "modules", `${config["module-name"]}.yaml`)
+      )
+    : await selectModule(config.webDevPath);
 
-  const checkpoint = config["checkpoint-folder"] ? config["checkpoint-folder"] : await selectCheckpoint(config.webDevPath, module);
+  const checkpoint = config["checkpoint-folder"]
+    ? config["checkpoint-folder"]
+    : await selectCheckpoint(config.webDevPath, module);
 
   const checkpointFolder = path.join(config.webDevPath, "library", checkpoint);
 

--- a/lib/publish-command/index.js
+++ b/lib/publish-command/index.js
@@ -7,6 +7,7 @@ const saveAssessment = require("./saveAssessment");
 const challengeOptions = require("../challenge-options");
 const readQualifiedFolder = require("./readQualifiedFolder");
 const saveChallengeItem = require("./saveChallengeItem");
+const readYaml = require("../readYaml");
 
 const debug = require("debug")("authoroo:assessment:index");
 
@@ -22,7 +23,19 @@ function builder(yargs) {
       "Qualified API access key copied from https://www.qualified.io/hire/account/integrations#api-key.",
     nargs: 1,
     type: "string",
-  });
+  })
+    .option("m", {
+      alias: "module-name",
+      demandOption: false,
+      type: "string",
+      describe: "the name of the module.yaml (without the .yaml extension) file that defines the module",
+    })
+    .option("c", {
+      alias: "checkpoint-folder",
+      demandOption: false,
+      type: "string",
+      describe: "the path of the checkpoint folder inside of library (omit `./library` i.e. `<checkpoint-folder-name>`",
+    });
 }
 
 async function handler(config) {
@@ -32,9 +45,9 @@ async function handler(config) {
     Accept: "application/json",
   };
 
-  const module = await selectModule(config.webDevPath);
+  const module = config["module-name"] ? await readYaml(path.join(config.webDevPath, "modules", `${config["module-name"]}.yaml` ))  : await selectModule(config.webDevPath);
 
-  const checkpoint = await selectCheckpoint(config.webDevPath, module);
+  const checkpoint = config["checkpoint-folder"] ? config["checkpoint-folder"] : await selectCheckpoint(config.webDevPath, module);
 
   const checkpointFolder = path.join(config.webDevPath, "library", checkpoint);
 

--- a/lib/publish-command/saveChallenge.js
+++ b/lib/publish-command/saveChallenge.js
@@ -41,7 +41,7 @@ async function saveChallenge(
 
   debug("Extracting phaseLabel", moduleCode, findPhaseLabel);
 
-  const phaseLabel = (moduleCode.match(findPhaseLabel) || [])[1] || moduleCode;
+  const phaseLabel = (moduleCode.match(findPhaseLabel) || [])[1] || checkpoint;
 
   const challenge = {
     data: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authoroo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
`authoroo publish -q <qualified-key> -m <module-name> -c <checkpoint-folder>` will publish without prompting for input
`authoroo extract -q <qualified-key> -c <checkpoint-folder> -a <assessment-id> -p <docker-port>` will extract an assessment without prompting for input.
